### PR TITLE
feat: Only display TOC if more than one header

### DIFF
--- a/src/pagetoc.js
+++ b/src/pagetoc.js
@@ -33,17 +33,19 @@ var updateFunction = function() {
 window.addEventListener('load', function() {
     var pagetoc = document.getElementsByClassName("pagetoc")[0];
     var elements = document.getElementsByClassName("header");
-    Array.prototype.forEach.call(elements, function (el) {
-        var link = document.createElement("a");
-        link.appendChild(document.createTextNode(el.text));
-        link.href = el.href;
-        link.classList.add("pagetoc-" + el.parentElement.tagName);
-        pagetoc.appendChild(link);
-      });
-    updateFunction.call();
+    
+    // Only display TOC if more than one header exists
+    if (elements.length > 1) {
+        Array.prototype.forEach.call(elements, function (el) {
+            var link = document.createElement("a");
+            link.appendChild(document.createTextNode(el.text));
+            link.href = el.href;
+            link.classList.add("pagetoc-" + el.parentElement.tagName);
+            pagetoc.appendChild(link);
+        });
+        updateFunction.call();
+    }
 });
-
-
 
 // Handle active elements on scroll
 window.addEventListener("scroll", updateFunction);


### PR DESCRIPTION
On pages with only one header, there is no reason to have a table of contents on the right as it will never be updated and is visual noise. 

E.g:
![image](https://user-images.githubusercontent.com/58985301/180628422-6e33dc7d-e319-4cb0-8ef2-1000f060828f.png)

This commit fixes that and only renders the table of contents when more than one header is shown.

With proposed changes: 
![image](https://user-images.githubusercontent.com/58985301/180628440-d95b9fd7-9fb5-4911-a2ec-afb347bc5076.png)
![image](https://user-images.githubusercontent.com/58985301/180628485-f2d7e365-b69c-464b-851b-39358b75969e.png)
